### PR TITLE
convert state to promise

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -20,3 +20,4 @@ export * from './flag';
 export * from './useUserSettings';
 export * from './useUserSettingsCompatibility';
 export * from './hpa-hooks';
+export * from './usePromise';

--- a/frontend/packages/console-shared/src/hooks/usePromise.ts
+++ b/frontend/packages/console-shared/src/hooks/usePromise.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const usePromise = <T extends any>(loaded: boolean, value: T) => {
+  const valueRef = React.useRef<T>();
+  valueRef.current = value;
+  const promiseRef = React.useRef<Promise<React.MutableRefObject<T>>>();
+  const resolveRef = React.useRef<(value: React.MutableRefObject<T>) => void>();
+  if (!promiseRef.current) {
+    promiseRef.current = new Promise((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }
+  if (loaded && resolveRef.current) {
+    resolveRef.current(valueRef);
+    resolveRef.current = undefined;
+  }
+  return promiseRef;
+};

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -18,6 +18,7 @@ import {
   GreenCheckCircleIcon,
   Modal,
   useUserSettingsCompatibility,
+  usePromise,
 } from '@console/shared';
 import { history } from '@console/internal/components/utils/router';
 import { TileViewPage } from '@console/internal/components/utils/tile-view-page';
@@ -332,6 +333,8 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     boolean
   >(userSettingsKey, storeKey, false);
 
+  const ignoreOperatorWarningPromiseRef = usePromise(loaded, ignoreOperatorWarning);
+
   const filteredItems = filterByArchAndOS(props.items);
 
   React.useEffect(() => {
@@ -353,8 +356,9 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     }
   };
 
-  const openOverlay = (item: OperatorHubItem) => {
-    if (!ignoreOperatorWarning && item.providerType === COMMUNITY_PROVIDER_TYPE) {
+  const openOverlay = async (item: OperatorHubItem) => {
+    const ignoreOperatorWarningRef = await ignoreOperatorWarningPromiseRef.current;
+    if (!ignoreOperatorWarningRef.current && item.providerType === COMMUNITY_PROVIDER_TYPE) {
       communityOperatorWarningModal({
         showCommunityOperators: (ignore) => showCommunityOperator(item)(ignore),
       });


### PR DESCRIPTION
Converts the user settings state to a promise which can be used in a callback along with async / await.